### PR TITLE
Custom FlatList component passed through props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ xcuserdata/
 *.xccheckout
 
 ## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
-build/
 DerivedData/
 *.moved-aside
 *.pbxuser
@@ -36,6 +35,7 @@ DerivedData/
 ### ReactNative.Buck Stack ###
 buck-out/
 .buckconfig.local
+.buckd/
 .buckversion
 .fakebuckversion
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ DerivedData/
 ### ReactNative.Buck Stack ###
 buck-out/
 .buckconfig.local
-.buckd/
 .buckversion
 .fakebuckversion
 

--- a/.gitignore
+++ b/.gitignore
@@ -233,7 +233,6 @@ typings/
 
 ### ReactNative.Gradle Stack ###
 .gradle
-/build/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/build/SmoothPicker.d.ts
+++ b/build/SmoothPicker.d.ts
@@ -1,0 +1,61 @@
+import React, { Component, ComponentType } from "react";
+import { FlatList, LayoutRectangle, FlatListProps, ListRenderItemInfo, StyleProp, ViewStyle } from "react-native";
+export interface ListReturn {
+    item: any;
+    index: number;
+}
+export interface Option extends ListReturn {
+    layout: LayoutRectangle;
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+}
+export declare type SnapAlignement = "start" | "center" | "end";
+export interface Snap {
+    snapToInterval: number;
+    snapToAlignment: SnapAlignement;
+}
+export declare type HandleSelection = (item: any, index: number, scrollPosition: number | null) => void;
+export interface SmoothPickerProps extends FlatListProps<any> {
+    onSelected?: (obj: ListReturn) => void;
+    offsetSelection?: number;
+    magnet?: boolean;
+    scrollAnimation?: boolean;
+    snapInterval?: number | null;
+    snapToAlignment?: SnapAlignement;
+    initialScrollToIndex?: number;
+    startMargin?: number;
+    endMargin?: number;
+    refFlatList?: React.MutableRefObject<FlatList | null>;
+    selectOnPress?: boolean;
+    styleButton?: StyleProp<ViewStyle>;
+    activeOpacityButton?: number;
+    flatListComponent: ComponentType<FlatListProps<any> & {
+        ref: React.RefObject<FlatList<any>>;
+    }>;
+}
+interface State {
+    selected: number;
+    scrollPosition: number | null;
+}
+declare class SmoothPicker extends Component<SmoothPickerProps, State> {
+    widthParent: number;
+    heightParent: number;
+    onMomentum: boolean;
+    fingerAction: boolean;
+    options: Option[];
+    countItems: number;
+    refList: React.RefObject<FlatList>;
+    state: {
+        selected: number;
+        scrollPosition: null;
+    };
+    componentDidMount(): void;
+    _alignAfterMount: () => void;
+    _save: (i: number, layout: LayoutRectangle, item: any, horizontal: boolean | null) => void;
+    _handleSelection: HandleSelection;
+    _renderItem: (info: ListRenderItemInfo<any>) => JSX.Element | null;
+    render(): JSX.Element;
+}
+export default SmoothPicker;

--- a/build/SmoothPicker.js
+++ b/build/SmoothPicker.js
@@ -1,0 +1,168 @@
+import React, { Component } from "react";
+import { View, FlatList, TouchableOpacity, } from "react-native";
+import onSelect from "./functions/onSelect";
+import alignSelect from "./functions/alignSelect";
+import { marginStart, marginEnd } from "./functions/onMargin";
+class SmoothPicker extends Component {
+    constructor() {
+        super(...arguments);
+        this.widthParent = 0;
+        this.heightParent = 0;
+        this.onMomentum = false;
+        this.fingerAction = false;
+        this.options = [];
+        this.countItems = 0;
+        this.refList = React.createRef();
+        this.state = {
+            selected: this.props.initialScrollToIndex || 1,
+            scrollPosition: null,
+        };
+        this._alignAfterMount = () => {
+            try {
+                const { horizontal = false, scrollAnimation = false, initialScrollToIndex, } = this.props;
+                if (typeof initialScrollToIndex !== "undefined") {
+                    const option = this.options[initialScrollToIndex];
+                    if (option) {
+                        alignSelect(horizontal, scrollAnimation, option, this.refList);
+                    }
+                }
+            }
+            catch (error) {
+                console.log("error", error);
+            }
+        };
+        this._save = (i, layout, item, horizontal) => {
+            const nOpt = {
+                layout,
+                item,
+                index: i,
+                top: 0,
+                bottom: 0,
+                left: 0,
+                right: 0,
+            };
+            this.options[i] = nOpt;
+            this.options.forEach((option) => {
+                const { index } = option;
+                if (horizontal) {
+                    let left = this.options[index - 1]
+                        ? this.options[index - 1].right
+                        : 0;
+                    let right = this.options[index - 1]
+                        ? left + this.options[index].layout.width
+                        : this.options[index].layout.width;
+                    this.options[index].right = right;
+                    this.options[index].left = left;
+                }
+                else {
+                    let top = this.options[index - 1]
+                        ? this.options[index - 1].bottom
+                        : 0;
+                    let bottom = this.options[index - 1]
+                        ? top + this.options[index].layout.height
+                        : this.options[index].layout.height;
+                    this.options[index].bottom = bottom;
+                    this.options[index].top = top;
+                }
+            });
+        };
+        this._handleSelection = (item, index, scrollPosition) => {
+            if (this.props.onSelected) {
+                this.props.onSelected({ item, index });
+            }
+            this.setState({
+                selected: index,
+                scrollPosition: scrollPosition,
+            });
+        };
+        this._renderItem = (info) => {
+            const { data, renderItem, horizontal = false, offsetSelection = 0, startMargin, endMargin, selectOnPress, styleButton = {}, activeOpacityButton = 0.2, } = this.props;
+            const { item, index } = info;
+            const handlePressOnItem = () => {
+                this._handleSelection(item, index, null);
+            };
+            if (!data) {
+                return null;
+            }
+            return (<View key={index} onLayout={({ nativeEvent: { layout } }) => {
+                this._save(index, layout, item, horizontal);
+                if (this.countItems === data.length - 1) {
+                    this.countItems = 0;
+                    this._alignAfterMount();
+                }
+                else {
+                    this.countItems = this.countItems + 1;
+                }
+            }} style={{
+                marginLeft: marginStart(horizontal, index, this.widthParent, offsetSelection, startMargin),
+                marginRight: marginEnd(horizontal, data.length - 1, index, this.widthParent, offsetSelection, endMargin),
+                marginTop: marginStart(!horizontal, index, this.heightParent, offsetSelection, startMargin),
+                marginBottom: marginEnd(!horizontal, data.length - 1, index, this.heightParent, offsetSelection, endMargin),
+            }}>
+        {renderItem && !selectOnPress && renderItem(info)}
+        {renderItem && selectOnPress && (<TouchableOpacity onPress={handlePressOnItem} style={styleButton} activeOpacity={activeOpacityButton}>
+            {renderItem(info)}
+          </TouchableOpacity>)}
+      </View>);
+        };
+    }
+    componentDidMount() {
+        if (this.props.refFlatList) {
+            this.props.refFlatList.current = this.refList.current;
+        }
+    }
+    render() {
+        const { horizontal = false, magnet = false, snapInterval = null, snapToAlignment = "center", scrollAnimation = false, flatListComponent, } = this.props;
+        const FlatListComponent = flatListComponent || FlatList;
+        let snap = {};
+        if (snapInterval) {
+            snap = {
+                snapToInterval: snapInterval,
+                snapToAlignment: snapToAlignment,
+            };
+        }
+        return (<FlatListComponent {...this.props} {...snap} onLayout={({ nativeEvent: { layout } }) => {
+            this.widthParent = layout.width;
+            this.heightParent = layout.height;
+        }} onScroll={({ nativeEvent }) => {
+            if (this.fingerAction) {
+                onSelect(nativeEvent, this.state.selected, this.options, this._handleSelection, this.state.scrollPosition, horizontal);
+            }
+        }} getItemLayout={(_, index) => {
+            let itemLayout;
+            if (snapInterval) {
+                itemLayout = {
+                    length: snapInterval,
+                    offset: snapInterval * index,
+                    index,
+                };
+            }
+            else {
+                itemLayout = {
+                    length: this.options[index]
+                        ? horizontal
+                            ? this.options[index].layout.width
+                            : this.options[index].layout.height
+                        : 30,
+                    offset: this.options[index]
+                        ? horizontal
+                            ? this.options[index].left
+                            : this.options[index].top
+                        : 30 * index,
+                    index,
+                };
+            }
+            return itemLayout;
+        }} onScrollBeginDrag={() => {
+            this.onMomentum = true;
+            this.fingerAction = true;
+        }} onMomentumScrollEnd={() => {
+            this.fingerAction = false;
+            if (this.onMomentum && magnet && !snapInterval) {
+                this.onMomentum = false;
+                alignSelect(horizontal, scrollAnimation, this.options[this.state.selected], this.refList);
+            }
+        }} renderItem={this._renderItem} ref={this.refList}/>);
+    }
+}
+export default SmoothPicker;

--- a/build/functions/alignSelect.d.ts
+++ b/build/functions/alignSelect.d.ts
@@ -1,0 +1,4 @@
+import { RefObject } from 'react';
+import { FlatList } from 'react-native';
+import { Option } from '../SmoothPicker';
+export default function (horizontal: boolean | null, scrollAnimation: boolean, option: Option, refFlatlist: RefObject<FlatList>): void;

--- a/build/functions/alignSelect.js
+++ b/build/functions/alignSelect.js
@@ -1,0 +1,18 @@
+export default function (horizontal, scrollAnimation, option, refFlatlist) {
+    try {
+        if (option) {
+            let newPosition = horizontal
+                ? option.left + option.layout.width / 2
+                : option.top + option.layout.width / 2;
+            if (refFlatlist.current !== null) {
+                refFlatlist.current.scrollToOffset({
+                    offset: newPosition,
+                    animated: scrollAnimation,
+                });
+            }
+        }
+    }
+    catch (e) {
+        console.log('error', e);
+    }
+}

--- a/build/functions/onMargin.d.ts
+++ b/build/functions/onMargin.d.ts
@@ -1,0 +1,2 @@
+export declare function marginStart(horizontal: boolean | null, index: number, size: number, offset: number, manualMargin: number | undefined): number;
+export declare function marginEnd(horizontal: boolean | null, length: number, index: number, size: number, offset: number, manualMargin: number | undefined): number;

--- a/build/functions/onMargin.js
+++ b/build/functions/onMargin.js
@@ -1,0 +1,18 @@
+export function marginStart(horizontal, index, size, offset, manualMargin) {
+    return horizontal
+        ? index === 0
+            ? manualMargin
+                ? manualMargin
+                : size / 2 + offset
+            : 0
+        : 0;
+}
+export function marginEnd(horizontal, length, index, size, offset, manualMargin) {
+    return horizontal
+        ? index === length
+            ? manualMargin
+                ? manualMargin
+                : size / 2 - offset
+            : 0
+        : 0;
+}

--- a/build/functions/onSelect.d.ts
+++ b/build/functions/onSelect.d.ts
@@ -1,0 +1,3 @@
+import { NativeScrollEvent } from 'react-native';
+import { Option, HandleSelection } from '../SmoothPicker';
+export default function (nativeEvent: NativeScrollEvent, selected: number, options: Option[], handleSelection: HandleSelection, scrollPosition: number | null, horizontal: boolean | null): void;

--- a/build/functions/onSelect.js
+++ b/build/functions/onSelect.js
@@ -1,0 +1,51 @@
+export default function (nativeEvent, selected, options, handleSelection, scrollPosition, horizontal) {
+    const cursor = horizontal
+        ? nativeEvent.contentOffset.x
+        : nativeEvent.contentOffset.y;
+    let SP = scrollPosition || 0;
+    if (scrollPosition === null) {
+        if (options[selected]) {
+            const option = options[selected];
+            SP = horizontal ? option.left : option.top;
+        }
+    }
+    const direction = horizontal
+        ? SP > cursor
+            ? 'right'
+            : 'left'
+        : SP > cursor
+            ? 'down'
+            : 'top';
+    switch (direction) {
+        case 'left':
+            if (options[selected + 1]) {
+                if (cursor > options[selected].right) {
+                    handleSelection(options[selected + 1].item, options[selected + 1].index, cursor);
+                }
+            }
+            break;
+        case 'right':
+            if (options[selected - 1]) {
+                if (cursor < options[selected].left) {
+                    handleSelection(options[selected - 1].item, options[selected - 1].index, cursor);
+                }
+            }
+            break;
+        case 'top':
+            if (options[selected + 1]) {
+                if (cursor > options[selected].bottom) {
+                    handleSelection(options[selected + 1].item, options[selected + 1].index, cursor);
+                }
+            }
+            break;
+        case 'down':
+            if (options[selected - 1]) {
+                if (cursor < options[selected].top) {
+                    handleSelection(options[selected - 1].item, options[selected - 1].index, cursor);
+                }
+            }
+            break;
+        default:
+            break;
+    }
+}

--- a/src/SmoothPicker.tsx
+++ b/src/SmoothPicker.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, ComponentType } from "react";
 import {
   View,
   FlatList,
@@ -8,10 +8,10 @@ import {
   ListRenderItemInfo,
   StyleProp,
   ViewStyle,
-} from 'react-native';
-import onSelect from './functions/onSelect';
-import alignSelect from './functions/alignSelect';
-import { marginStart, marginEnd } from './functions/onMargin';
+} from "react-native";
+import onSelect from "./functions/onSelect";
+import alignSelect from "./functions/alignSelect";
+import { marginStart, marginEnd } from "./functions/onMargin";
 
 export interface ListReturn {
   item: any;
@@ -19,21 +19,25 @@ export interface ListReturn {
 }
 
 export interface Option extends ListReturn {
-  layout: LayoutRectangle,
+  layout: LayoutRectangle;
   left: number;
   top: number;
   right: number;
   bottom: number;
 }
 
-export type SnapAlignement = 'start' | 'center' | 'end';
+export type SnapAlignement = "start" | "center" | "end";
 
 export interface Snap {
-  snapToInterval: number,
-  snapToAlignment: SnapAlignement,
+  snapToInterval: number;
+  snapToAlignment: SnapAlignement;
 }
 
-export type HandleSelection =  (item: any, index: number, scrollPosition: number | null) => void;
+export type HandleSelection = (
+  item: any,
+  index: number,
+  scrollPosition: number | null
+) => void;
 
 export interface SmoothPickerProps extends FlatListProps<any> {
   onSelected?: (obj: ListReturn) => void;
@@ -47,8 +51,11 @@ export interface SmoothPickerProps extends FlatListProps<any> {
   endMargin?: number;
   refFlatList?: React.MutableRefObject<FlatList | null>;
   selectOnPress?: boolean;
-  styleButton?:  StyleProp<ViewStyle>;
+  styleButton?: StyleProp<ViewStyle>;
   activeOpacityButton?: number;
+  flatListComponent: ComponentType<
+    FlatListProps<any> & { ref: React.RefObject<FlatList<any>> }
+  >;
 }
 
 interface State {
@@ -83,23 +90,23 @@ class SmoothPicker extends Component<SmoothPickerProps, State> {
         scrollAnimation = false,
         initialScrollToIndex,
       } = this.props;
-      if (typeof initialScrollToIndex !== 'undefined') {
+      if (typeof initialScrollToIndex !== "undefined") {
         const option = this.options[initialScrollToIndex];
         if (option) {
-          alignSelect(
-            horizontal,
-            scrollAnimation,
-            option,
-            this.refList
-          );
+          alignSelect(horizontal, scrollAnimation, option, this.refList);
         }
       }
     } catch (error) {
-      console.log('error', error);
+      console.log("error", error);
     }
   };
 
-  _save = (i: number, layout: LayoutRectangle, item: any, horizontal: boolean | null) => {
+  _save = (
+    i: number,
+    layout: LayoutRectangle,
+    item: any,
+    horizontal: boolean | null
+  ) => {
     const nOpt: Option = {
       layout,
       item,
@@ -107,21 +114,25 @@ class SmoothPicker extends Component<SmoothPickerProps, State> {
       top: 0,
       bottom: 0,
       left: 0,
-      right:0,
+      right: 0,
     };
     this.options[i] = nOpt;
 
-    this.options.forEach(option => {
+    this.options.forEach((option) => {
       const { index } = option;
       if (horizontal) {
-        let left: number = this.options[index - 1] ? this.options[index - 1].right : 0;
+        let left: number = this.options[index - 1]
+          ? this.options[index - 1].right
+          : 0;
         let right: number = this.options[index - 1]
           ? left + this.options[index].layout.width
           : this.options[index].layout.width;
         this.options[index].right = right;
         this.options[index].left = left;
       } else {
-        let top: number = this.options[index - 1] ? this.options[index - 1].bottom : 0;
+        let top: number = this.options[index - 1]
+          ? this.options[index - 1].bottom
+          : 0;
         let bottom: number = this.options[index - 1]
           ? top + this.options[index].layout.height
           : this.options[index].layout.height;
@@ -141,7 +152,7 @@ class SmoothPicker extends Component<SmoothPickerProps, State> {
     });
   };
 
-  _renderItem = (info: ListRenderItemInfo<any>):(JSX.Element | null) => {
+  _renderItem = (info: ListRenderItemInfo<any>): JSX.Element | null => {
     const {
       data,
       renderItem,
@@ -223,14 +234,17 @@ class SmoothPicker extends Component<SmoothPickerProps, State> {
     );
   };
 
-  render(): JSX.Element {
+  render() {
     const {
       horizontal = false,
       magnet = false,
       snapInterval = null,
-      snapToAlignment = 'center',
+      snapToAlignment = "center",
       scrollAnimation = false,
+      flatListComponent,
     } = this.props;
+
+    const FlatListComponent = flatListComponent || FlatList;
 
     let snap: Snap = {} as Snap;
     if (snapInterval) {
@@ -240,7 +254,7 @@ class SmoothPicker extends Component<SmoothPickerProps, State> {
       };
     }
     return (
-      <FlatList
+      <FlatListComponent
         {...this.props}
         {...snap}
         onLayout={({ nativeEvent: { layout } }) => {


### PR DESCRIPTION
The scroll functionality doesn't work as intended when using it inside `react-native-bottom-sheet`. This is a known limitation in that library which specifically targets the FlatList exported by `react-native`. Using the `FlatList` exported by `react-native-gesture-handler` works fine so this PR focuses on providing a custom FlatList component via props.

Please leave comments if the code is not up to the standards or if any changes are required.